### PR TITLE
Formatting, Allows travis build to pass

### DIFF
--- a/src/main/java/org/poweredrails/impl/event/EventBus.java
+++ b/src/main/java/org/poweredrails/impl/event/EventBus.java
@@ -1,62 +1,61 @@
 /*
  * This file is a component of Powered Rails, this license makes sure any work
- * associated with Powered Rails, must follow the conditions of the license
- * included.
- * 
+ * associated with Powered Rails, must follow the conditions of the license included.
+ *
  * Copyright 2015 PoweredRails
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
- * 
- * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.poweredrails.impl.event;
 
 import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
 import org.poweredrails.railsapi.event.Event;
 import org.poweredrails.railsapi.event.Listener;
 
-import com.google.common.collect.Lists;
-
 public class EventBus {
 
-	private List<RegisteredListener<?>> listeners;
-	
-	{
-		listeners = Lists.newArrayList();
-	}
-	
-	public <T extends Event> void invoke(T event) {
-		for (RegisteredListener<?> listener : listeners) {
-			try {
-				listener.invoke(event);
-			} catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
-				e.printStackTrace();
-			}
-		}
-	}
-	
-	public <T extends Listener> void register(T listener) {
-		listeners.add(new RegisteredListener<T>(listener));
-	}
-	
-	public void unregister(Listener listener) {
-		Iterator<RegisteredListener<?>> it = listeners.iterator();
-		while (it.hasNext()) {
-			RegisteredListener<?> lis = it.next();
-			if (listener.equals(lis.getListener()))
-				it.remove();
-		}
-	}
-	
+    private List<RegisteredListener<?>> listeners;
+
+    {
+        this.listeners = new ArrayList<>();
+    }
+
+    public <T extends Event> void invoke(T event) {
+        for (RegisteredListener<?> listener : this.listeners) {
+            try {
+                listener.invoke(event);
+            } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    public <T extends Listener> void register(T listener) {
+        this.listeners.add(new RegisteredListener<T>(listener));
+    }
+
+    public void unregister(Listener listener) {
+        Iterator<RegisteredListener<?>> it = this.listeners.iterator();
+        while (it.hasNext()) {
+            RegisteredListener<?> lis = it.next();
+            if (listener.equals(lis.getListener())) {
+                it.remove();
+            }
+        }
+    }
+
 }

--- a/src/main/java/org/poweredrails/impl/event/RegisteredListener.java
+++ b/src/main/java/org/poweredrails/impl/event/RegisteredListener.java
@@ -1,21 +1,20 @@
 /*
  * This file is a component of Powered Rails, this license makes sure any work
- * associated with Powered Rails, must follow the conditions of the license
- * included.
- * 
+ * associated with Powered Rails, must follow the conditions of the license included.
+ *
  * Copyright 2015 PoweredRails
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
- * 
- * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.poweredrails.impl.event;
 
@@ -24,56 +23,64 @@ import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Map;
 
-import org.poweredrails.railsapi.event.*;
+import org.poweredrails.railsapi.event.Event;
+import org.poweredrails.railsapi.event.Listener;
+import org.poweredrails.railsapi.event.Subscribe;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
 public class RegisteredListener<T extends Listener> {
 
-	private T listener;
-	private Map<Class<? extends Event>, List<Method>> eventMap;
+    private T listener;
+    private Map<Class<? extends Event>, List<Method>> eventMap;
 
-	@SuppressWarnings("unchecked")
-	public RegisteredListener(T listener) {
-		this.listener = listener;
-		this.eventMap = Maps.newHashMap();
+    @SuppressWarnings("unchecked")
+    public RegisteredListener(T listener) {
+        this.listener = listener;
+        this.eventMap = Maps.newHashMap();
 
-		Class<? extends Listener> clazz = listener.getClass();
-		for (Method method : clazz.getMethods()) {
+        Class<? extends Listener> clazz = listener.getClass();
+        for (Method method : clazz.getMethods()) {
 
-			if (!method.isAnnotationPresent(Subscribe.class))
-				continue;
+            if (!method.isAnnotationPresent(Subscribe.class)) {
+                continue;
+            }
 
-			Class<?>[] params = method.getParameterTypes();
-			if (params.length != 1)
-				continue;
+            Class<?>[] params = method.getParameterTypes();
+            if (params.length != 1) {
+                continue;
+            }
 
-			Class<?> param = params[0];
-			if (!Event.class.isAssignableFrom(param))
-				continue;
+            Class<?> param = params[0];
+            if (!Event.class.isAssignableFrom(param)) {
+                continue;
+            }
 
-			Class<? extends Event> eventClass = (Class<? extends Event>) param;
-			List<Method> methods = eventMap.get(eventClass);
-			if (methods == null) {
-				methods = Lists.newArrayList();
-				eventMap.put(eventClass, methods);
-			}
-			methods.add(method);
-		}
+            Class<? extends Event> eventClass = (Class<? extends Event>) param;
+            List<Method> methods = this.eventMap.get(eventClass);
+            if (methods == null) {
+                methods = Lists.newArrayList();
+                this.eventMap.put(eventClass, methods);
+            }
+            methods.add(method);
+        }
 
-	}
+    }
 
-	public <E extends Event> void invoke(E evt) throws IllegalAccessException, IllegalArgumentException, InvocationTargetException {
-		List<Method> methods = eventMap.get(evt.getClass());
-		if (methods == null)
-			return;
-		for (Method method : methods)
-			method.invoke(listener, evt);
-	}
+    public <E extends Event> void invoke(E evt) throws IllegalAccessException,
+            IllegalArgumentException, InvocationTargetException {
+        List<Method> methods = this.eventMap.get(evt.getClass());
+        if (methods == null) {
+            return;
+        }
+        for (Method method : methods) {
+            method.invoke(this.listener, evt);
+        }
+    }
 
-	public Listener getListener() {
-		return listener;
-	}
+    public Listener getListener() {
+        return this.listener;
+    }
 
 }


### PR DESCRIPTION
* Fix license headers
* Change tabs to spaces
* Removed usage of ```Lists.newArrayList()``` as javadocs says its basically "deprecated" for 1.7 plus and our project is 1.8
* ```Lists.newArrayList()``` is now ```new ArrayList<>()``` Following the 1.7 + "diamond standard" 
* Add "this." when referencing instanced variables because gradle formatter doesn't like it @VectrixU are we going to follow this or can u remove this check somehow
* Instead of importing with "*" import each class and interface separately 